### PR TITLE
feature/EIL-5696-set-tax-prefix-and-tax-template-as-mandatory-and-set-pajakio-tab-hidden

### DIFF
--- a/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/indonesia_localization_settings/indonesia_localization_settings.json
+++ b/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/indonesia_localization_settings/indonesia_localization_settings.json
@@ -163,6 +163,7 @@
   {
    "fieldname": "pajakio_settings_tab",
    "fieldtype": "Tab Break",
+   "hidden": 1,
    "label": "Pajak.io Settings"
   },
   {
@@ -254,7 +255,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-18 17:03:45.322898",
+ "modified": "2024-11-21 17:24:50.296835",
  "modified_by": "Administrator",
  "module": "Erpnext Indonesia Localization",
  "name": "Indonesia Localization Settings",

--- a/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/tax_prefix_code/tax_prefix_code.json
+++ b/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/tax_prefix_code/tax_prefix_code.json
@@ -14,14 +14,16 @@
    "fieldname": "tax_prefix_code",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Tax Prefix Code"
+   "label": "Tax Prefix Code",
+   "reqd": 1
   },
   {
    "fieldname": "sales_taxes_and_charges_template",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Sales Taxes and Charges Template",
-   "options": "Sales Taxes and Charges Template"
+   "options": "Sales Taxes and Charges Template",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_2",
@@ -31,12 +33,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-08-19 15:36:29.925806",
+ "modified": "2024-11-21 17:25:35.957720",
  "modified_by": "Administrator",
  "module": "Erpnext Indonesia Localization",
  "name": "Tax Prefix Code",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
feat(EIL-5696): set tax prefix code and tax template as mandatory, set pajak.io tab hidden