### PR TITLE
limit 6 digit of invoice items code to match coretax required format.

### DIFF
--- a/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/coretax_xml_exporter/coretax_xml_exporter.py
+++ b/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/coretax_xml_exporter/coretax_xml_exporter.py
@@ -224,7 +224,8 @@ def mapping_sales_invoices(invoice_docs, company_doc, doc):
 
 			invoice_entry["items"].append({
 				"opt": item["kode_barang_jasa_opt"],
-				"code": item["kode_barang_jasa_ref"],
+				# "code": item["kode_barang_jasa_ref"],
+				"code": (item["kode_barang_jasa_ref"])[:6],
 				"name": item["item_name"],
 				"unit": item["unit_ref"],
 				"price": item["rate"],


### PR DESCRIPTION
Previously transaction code print full item code like "000000-Barang" to XML
Coretax reject this format, and accept "000000" format.