### PR TITLE
feat/EIL-10637-fix-and-adjust-xml-export-to-use-only-code-from-coretax-barang-jasa-ref

### DIFF
--- a/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/coretax_xml_exporter/coretax_xml_exporter.py
+++ b/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/coretax_xml_exporter/coretax_xml_exporter.py
@@ -224,7 +224,7 @@ def mapping_sales_invoices(invoice_docs, company_doc, doc):
 
 			invoice_entry["items"].append({
 				"opt": item["kode_barang_jasa_opt"],
-				"code": item["kode_barang_jasa_ref"],
+				"code": frappe.get_value("CoreTax Barang Jasa Ref", item["kode_barang_jasa_ref"], "code"),
 				"name": item["item_name"],
 				"unit": item["unit_ref"],
 				"price": item["rate"],


### PR DESCRIPTION
feat(EIl-10637): use code from coretax barang jasa ref instead of name for <code> in xml file