### PR TITLE
feat/EIL-10949-modify-populating-coretax-related-fields-from-default-sales-taxes-and-charges-template

### DIFF
--- a/erpnext_indonesia_localization/erpnext_indonesia_localization/doc_events/sales_invoice.py
+++ b/erpnext_indonesia_localization/erpnext_indonesia_localization/doc_events/sales_invoice.py
@@ -267,3 +267,30 @@ def calculate_other_tax_base_amount_and_total(doc, method):
 				item.vat_amount = item.net_amount * tax_template_doc.rate / 100
 				doc.total_other_tax_base += item.net_amount
 				doc.total_luxury_goods_tax += item.luxury_goods_tax_amount
+
+
+def set_sales_taxes_template_values(doc, method):
+	fields_to_sync = ['transaction_code', 'tax_additional_info', 'tax_facility_stamp']
+
+	if doc.taxes_and_charges:
+		taxes_template = frappe.db.get_value(
+			"Sales Taxes and Charges Template",
+			doc.taxes_and_charges,
+			['transaction_code', 'tax_additional_info', 'tax_facility_stamp'],
+			as_dict=True
+		)
+	else:
+		taxes_template = frappe.db.get_value(
+			"Sales Taxes and Charges Template",
+			{
+				"company": doc.company,
+				"is_default": True
+			},
+			fields_to_sync,
+			as_dict=True
+		)
+
+	if taxes_template:
+		for field in fields_to_sync:
+			if not doc.get(field):
+				doc.set(field, taxes_template.get(field))

--- a/erpnext_indonesia_localization/hooks.py
+++ b/erpnext_indonesia_localization/hooks.py
@@ -160,7 +160,8 @@ doc_events = {
 			"erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.set_tin_status_before_cancel_si",
 			"erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.set_si_had_tin_before"
 		],
-		"before_save": "erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.calculate_other_tax_base_amount_and_total"
+		"before_save": "erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.calculate_other_tax_base_amount_and_total",
+		"validate": "erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.set_sales_taxes_template_values"
 	}
 }
 

--- a/erpnext_indonesia_localization/public/js/sales_invoice.js
+++ b/erpnext_indonesia_localization/public/js/sales_invoice.js
@@ -13,7 +13,7 @@ frappe.ui.form.on('Sales Invoice', {
         };
     },
     onload: function (frm) {
-        if (frm.doc.docstatus != 1) {
+        if (frm.is_new()) {
             set_sales_taxes_template_values(frm, {company: frm.doc.company, is_default: 1});
         }
 

--- a/erpnext_indonesia_localization/tests/test_sales_invoice.py
+++ b/erpnext_indonesia_localization/tests/test_sales_invoice.py
@@ -1,0 +1,92 @@
+from unittest.mock import patch, MagicMock, call
+from erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice import set_sales_taxes_template_values
+
+
+@patch("erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.frappe")
+def test_set_values_from_specific_taxes_and_charges(mock_frappe):
+	mock_doc = MagicMock()
+	mock_doc.taxes_and_charges = "PPN Penjualan 12%"
+	mock_doc.get.return_value = None
+
+	mock_frappe.db.get_value.return_value = {
+		"transaction_code": "03",
+		"tax_additional_info": "TD.00501",
+		"tax_facility_stamp": "TD.01101"
+	}
+
+	set_sales_taxes_template_values(mock_doc, "after_insert")
+
+	mock_frappe.db.get_value.assert_called_once_with(
+		"Sales Taxes and Charges",
+		"PPN Penjualan 12%",
+		["transaction_code", "tax_additional_info", "tax_facility_stamp"],
+		as_dict=True
+	)
+
+	mock_doc.set.assert_has_calls([
+		call('transaction_code', '03'),
+		call('tax_additional_info', 'TD.00501'),
+		call('tax_facility_stamp', 'TD.01101')
+	])
+
+	assert mock_doc.set.call_count == 3
+
+
+@patch("erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.frappe")
+def test_set_values_from_default_template(mock_frappe):
+	mock_doc = MagicMock()
+	mock_doc.taxes_and_charges = None
+	mock_doc.get.return_value = None
+	mock_doc.company = "PT Test Company"
+
+	mock_frappe.db.get_value.return_value = {
+		"transaction_code": "01",
+		"tax_additional_info": "TD.00501",
+		"tax_facility_stamp": "TD.01101"
+	}
+
+	set_sales_taxes_template_values(mock_doc, "after_insert")
+
+	mock_frappe.db.get_value.assert_called_once_with(
+		'Sales Taxes and Charges Template',
+		{
+			'company': 'PT Test Company',
+			'is_default': True
+		},
+		['transaction_code', 'tax_additional_info', 'tax_facility_stamp'],
+		as_dict=True
+	)
+
+	mock_doc.set.assert_has_calls([
+		call('transaction_code', '01'),
+		call('tax_additional_info', 'TD.00501'),
+		call('tax_facility_stamp', 'TD.01101')
+	])
+
+	assert mock_doc.set.call_count == 3
+
+
+@patch("erpnext_indonesia_localization.erpnext_indonesia_localization.doc_events.sales_invoice.frappe")
+def test_do_not_overwrite_existing_values(mock_frappe):
+	mock_doc = MagicMock()
+	mock_doc.taxes_and_charges = "PPN Penjualan 12%"
+
+	mock_doc.get.side_effect = [
+		"01",
+		"TD.00501",
+		None
+	]
+
+	mock_frappe.db.get_value.return_value = {
+		"transaction_code": "01",
+		"tax_additional_info": "TD.00501",
+		"tax_facility_stamp": "TD.01101"
+	}
+
+	set_sales_taxes_template_values(mock_doc, "after_insert")
+
+	mock_doc.set.assert_has_calls([
+        call('tax_facility_stamp', 'TD.01101')
+    ])
+
+	assert mock_doc.set.call_count == 1


### PR DESCRIPTION
feat(EIL-8656): add sales taxes template values synchronization on sales invoice