### PR TITLE
hotfix/disable-github-workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 
 name: CI
 
-on:
-  push:
-    branches:
-      - develop
-  pull_request:
+#on:
+#  push:
+#    branches:
+#      - develop
+#  pull_request:
 
 concurrency:
   group: develop-erpnext_indonesia_localization-${{ github.event.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 
 name: CI
 
-#on:
-#  push:
-#    branches:
-#      - develop
-#  pull_request:
-
 concurrency:
   group: develop-erpnext_indonesia_localization-${{ github.event.number }}
   cancel-in-progress: true


### PR DESCRIPTION
fix: disable gitlab ci as it's no longer in use