### PR TITLE
feat/consider_item_discount_for_XML_generation

### DIFF
--- a/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/coretax_xml_exporter/coretax_xml_exporter.py
+++ b/erpnext_indonesia_localization/erpnext_indonesia_localization/doctype/coretax_xml_exporter/coretax_xml_exporter.py
@@ -227,17 +227,23 @@ def mapping_sales_invoices(invoice_docs, company_doc, doc):
 		for item in si_items:
 			template_tax = frappe.get_value("Sales Taxes and Charges",
 											{"parent": invoice["name"], "idx": 1},
-											["use_temporary_rate", "rate", "temporary_rate"],
+											["use_temporary_rate", "rate", "temporary_rate", "included_in_print_rate"],
 											as_dict=True)
+			
+			discount_amount_ex_tax = (
+				item["discount_amount"] / ((template_tax.rate / 100) + 1)
+				if template_tax.included_in_print_rate
+				else item["discount_amount"]
+			)
 
 			invoice_entry["items"].append({
 				"opt": item["kode_barang_jasa_opt"],
 				"code": frappe.get_value("CoreTax Barang Jasa Ref", item["kode_barang_jasa_ref"], "code") or "000000",
 				"name": escape_xml_fast(item["item_name"]),
 				"unit": item["unit_ref"],
-				"price": item["net_rate"],
+				"price": item["net_rate"] + discount_amount_ex_tax,
 				"qty": item["qty"],
-				"total_discount": item["discount_amount"] * item["qty"],
+				"total_discount": discount_amount_ex_tax * item["qty"],
 				"tax_base": item["net_amount"],
 				"other_tax_base": item["other_tax_base_amount"],
 				"vat": item["vat_amount"],


### PR DESCRIPTION
previously item rate is using net_rate (after discounts, etc), it represented to item rate before discount in coretax. This makes calculation of
`Total Harga - Potongan harga` not equal with `DPP / Penghasilan Kotor`
<img width="1092" height="440" alt="image" src="https://github.com/user-attachments/assets/7211f772-94ce-4081-bcf5-9b8fbe23d6e6" />


This fixes that issue